### PR TITLE
GOLD-402 Handle JIRA's other error message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.14
 require (
 	github.com/mailru/easyjson v0.7.1
 	github.com/pinpt/adf v1.2.1
-	github.com/pinpt/agent/v4 v4.0.4
+	github.com/pinpt/agent/v4 v4.0.6
 	github.com/pinpt/confluence v0.0.0-20201002160018-31b5a3a83f95
-	github.com/pinpt/integration-sdk v0.0.1233
+	github.com/pinpt/integration-sdk v0.0.1235
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,8 @@ github.com/pinpt/adf v1.2.1 h1:AI/siyFtTn0bP+QMYoMRLNM6wHtc5BQAF5muYTMJnc8=
 github.com/pinpt/adf v1.2.1/go.mod h1:KUu5fYDXAQjSR/ZNqyLUQHVbMulfe21CCACOH4oXwLE=
 github.com/pinpt/agent/v4 v4.0.4 h1:mDrUDhrqxbJ7tdLH18+6RvU/aM+LTW5p2+E3zvJHI5U=
 github.com/pinpt/agent/v4 v4.0.4/go.mod h1:fBqOPeLNMw3soESSc5x+GhJ2FC/2NXnVS92Cf7cEUjo=
+github.com/pinpt/agent/v4 v4.0.6 h1:oB982G2Pg8NWmPSP4Lh374E0DPxu4pvQJdE2weyrafE=
+github.com/pinpt/agent/v4 v4.0.6/go.mod h1:hi/8XL8eJSCfUpEpLlzOmBtW+4HvnlWEQiunaYB3aNs=
 github.com/pinpt/confluence v0.0.0-20201002160018-31b5a3a83f95 h1:Eo5GC829sI+VCBpkHtko3L+b094t94nEK4liSmVZmr0=
 github.com/pinpt/confluence v0.0.0-20201002160018-31b5a3a83f95/go.mod h1:vEZ93LbfGGT/02pZdVLcOu8vWUeaeaWzj8JeXrckE2E=
 github.com/pinpt/go-common/v10 v10.0.17 h1:434frXTXGxb/lFrotRL61Y+jpCR+EOtDR67cigyX+Fo=
@@ -341,6 +343,8 @@ github.com/pinpt/httpclient v0.0.0-20200627153820-d374c2f15648 h1:hkfjX+KJmcSLpF
 github.com/pinpt/httpclient v0.0.0-20200627153820-d374c2f15648/go.mod h1:SzzGa0kOT+frqT6ABgV69U9+jlMU98XkmKup+HEZRVI=
 github.com/pinpt/integration-sdk v0.0.1233 h1:AE5ab5lGjmQdldli0pz74Ph0Te0wuXInSBtxvn5ycLI=
 github.com/pinpt/integration-sdk v0.0.1233/go.mod h1:M3xXTd460Cr+ulMNcEI1/npfKIHTOvO98jySA9rGo88=
+github.com/pinpt/integration-sdk v0.0.1235 h1:IXuStl7eKxYkjwS6GgeJQM6pTnMmbP6O7hq/C0/ZtDQ=
+github.com/pinpt/integration-sdk v0.0.1235/go.mod h1:M3xXTd460Cr+ulMNcEI1/npfKIHTOvO98jySA9rGo88=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/agile.go
+++ b/internal/agile.go
@@ -1187,7 +1187,7 @@ func (i *JiraIntegration) updateSprint(logger sdk.Logger, mutation sdk.Mutation,
 			return nil, fmt.Errorf("error marshaling sprint update: %w", err)
 		}
 		if _, err := client.Post(bytes.NewBuffer(buf), nil, authConfig.Middleware...); err != nil {
-			return nil, fmt.Errorf("error updating sprint %s: %w", refID, err)
+			return nil, fmt.Errorf("error updating sprint %s: %s", refID, getJiraErrorMessage(err))
 		}
 	}
 	if len(event.Set.IssueRefIDs) > 0 {
@@ -1200,7 +1200,7 @@ func (i *JiraIntegration) updateSprint(logger sdk.Logger, mutation sdk.Mutation,
 				return fmt.Errorf("error marshaling sprint issue mover: %w", err)
 			}
 			if _, err := client.Post(bytes.NewBuffer(buf), nil, authConfig.Middleware...); err != nil {
-				return fmt.Errorf("error updating sprint (%s) issues: %w", refID, err)
+				return fmt.Errorf("error updating sprint (%s) issues: %s", refID, getJiraErrorMessage(err))
 			}
 			return nil
 		})
@@ -1258,7 +1258,7 @@ func (i *JiraIntegration) createSprint(logger sdk.Logger, mutation sdk.Mutation,
 		return nil, fmt.Errorf("error marshaling sprint update: %w", err)
 	}
 	if _, err := client.Post(bytes.NewBuffer(buf), nil, authConfig.Middleware...); err != nil {
-		return nil, fmt.Errorf("error creating sprint: %w", err)
+		return nil, fmt.Errorf("error creating sprint: %s", getJiraErrorMessage(err))
 	}
 	refID := event.BoardRefIDs[0]
 	return &sdk.MutationResponse{

--- a/internal/issue.go
+++ b/internal/issue.go
@@ -202,7 +202,7 @@ func (i issueSource) ToModel(customerID string, integrationInstanceID string, is
 	issue.RefID = i.ID
 	issue.RefType = refType
 	issue.Identifier = i.Key
-	issue.ProjectID = sdk.NewWorkProjectID(customerID, fields.Project.ID, refType)
+	issue.ProjectID = sdk.StringPointer(sdk.NewWorkProjectID(customerID, fields.Project.ID, refType))
 	issue.ID = sdk.NewWorkIssueID(customerID, i.ID, refType)
 	issue.IntegrationInstanceID = sdk.StringPointer(integrationInstanceID)
 
@@ -228,7 +228,7 @@ func (i issueSource) ToModel(customerID string, integrationInstanceID string, is
 	comments := make([]*sdk.WorkIssueComment, 0)
 
 	for _, comment := range fields.Comment.Comments {
-		thecomment, err := comment.ToModel(customerID, integrationInstanceID, websiteURL, userManager, issue.ProjectID, issue.ID, i.Key)
+		thecomment, err := comment.ToModel(customerID, integrationInstanceID, websiteURL, userManager, *issue.ProjectID, issue.ID, i.Key)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could create issue comment for jira issue: %v err: %v", i.Key, err)
 		}
@@ -671,7 +671,7 @@ func (i *JiraIntegration) createIssue(logger sdk.Logger, mutation sdk.Mutation, 
 	if reporterRefID == "" {
 		return nil, errors.New("no ref_id found for requesting user")
 	}
-	createMutation.Fields["reporter"] = idValue{reporterRefID}
+	// createMutation.Fields["reporter"] = idValue{reporterRefID}
 	createMutation.Fields["summary"] = event.Title
 	createMutation.Fields["issuetype"] = idValue{*event.Type.RefID}
 	createMutation.Fields["project"] = idValue{event.ProjectRefID}

--- a/internal/issue.go
+++ b/internal/issue.go
@@ -671,7 +671,6 @@ func (i *JiraIntegration) createIssue(logger sdk.Logger, mutation sdk.Mutation, 
 	if reporterRefID == "" {
 		return nil, errors.New("no ref_id found for requesting user")
 	}
-	// createMutation.Fields["reporter"] = idValue{reporterRefID}
 	createMutation.Fields["summary"] = event.Title
 	createMutation.Fields["issuetype"] = idValue{*event.Type.RefID}
 	createMutation.Fields["project"] = idValue{event.ProjectRefID}

--- a/internal/issue.go
+++ b/internal/issue.go
@@ -728,7 +728,7 @@ func (i *JiraIntegration) createIssue(logger sdk.Logger, mutation sdk.Mutation, 
 	client := i.httpmanager.New(theurl, nil)
 	resp, err := client.Post(sdk.StringifyReader(createMutation), nil, authConfig.Middleware...)
 	if err != nil {
-		sdk.LogError(logger, "error creating an issue", "body", string(resp.Body), "customer_id", mutation.CustomerID(), "request", sdk.Stringify(createMutation))
+		sdk.LogError(logger, "error creating an issue", "err", err, "body", string(resp.Body), "customer_id", mutation.CustomerID(), "request", sdk.Stringify(createMutation))
 		return nil, fmt.Errorf("mutation failed: %s", getJiraErrorMessage(err))
 	}
 	var respStruct struct {

--- a/internal/issue.go
+++ b/internal/issue.go
@@ -729,7 +729,7 @@ func (i *JiraIntegration) createIssue(logger sdk.Logger, mutation sdk.Mutation, 
 	client := i.httpmanager.New(theurl, nil)
 	resp, err := client.Post(sdk.StringifyReader(createMutation), nil, authConfig.Middleware...)
 	if err != nil {
-		sdk.LogError(logger, "error creating an issue", "err", getJiraErrorMessage(err), "body", string(resp.Body), "customer_id", mutation.CustomerID(), "request", sdk.Stringify(createMutation))
+		sdk.LogError(logger, "error creating an issue", "body", string(resp.Body), "customer_id", mutation.CustomerID(), "request", sdk.Stringify(createMutation))
 		return nil, fmt.Errorf("mutation failed: %s", getJiraErrorMessage(err))
 	}
 	var respStruct struct {

--- a/internal/util.go
+++ b/internal/util.go
@@ -189,14 +189,23 @@ type state struct {
 	integrationInstanceID string
 }
 
+type jiraErrResp struct {
+	ErrorMessages []string          `json:"errorMessages"`
+	Errors        map[string]string `json:"errors"`
+}
+
 func getJiraErrorMessage(err error) string {
 	if ok, _, r := sdk.IsHTTPError(err); ok {
-		var errResp struct {
-			ErrorMessages []string `json:"errorMessages"`
-		}
+		var errResp jiraErrResp
 		json.NewDecoder(r).Decode(&errResp)
 		if len(errResp.ErrorMessages) > 0 {
 			return errResp.ErrorMessages[0]
+		}
+		if len(errResp.Errors) > 0 {
+			for k, v := range errResp.Errors {
+				// return the first one
+				return fmt.Sprintf("%s: %s", k, v)
+			}
 		}
 	}
 	return err.Error()

--- a/internal/util.go
+++ b/internal/util.go
@@ -197,7 +197,9 @@ type jiraErrResp struct {
 func getJiraErrorMessage(err error) string {
 	if ok, _, r := sdk.IsHTTPError(err); ok {
 		var errResp jiraErrResp
-		json.NewDecoder(r).Decode(&errResp)
+		if derr := json.NewDecoder(r).Decode(&errResp); derr != nil {
+			return fmt.Sprintf("cannot decode jira error(%s): %s", derr.Error(), err.Error())
+		}
 		if len(errResp.ErrorMessages) > 0 {
 			return errResp.ErrorMessages[0]
 		}

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -1,8 +1,11 @@
 package internal
 
 import (
+	"bytes"
+	"net/http"
 	"testing"
 
+	"github.com/pinpt/agent/v4/sdk"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,4 +24,14 @@ func TestRemove(t *testing.T) {
 		"q",
 	}
 	assert.EqualValues([]string{"1", "a"}, removeKeys(vals, []string{"2", "q"}))
+}
+
+func TestGetJiraErrorMessage(t *testing.T) {
+	assert := assert.New(t)
+	netErr := sdk.HTTPError{
+		StatusCode: http.StatusBadRequest,
+		Body:       bytes.NewBuffer([]byte(`{"errorMessages":[],"errors":{"summary":"Field 'summary' cannot be set. It is not on the appropriate screen, or unknown.","description":"Field 'description' cannot be set. It is not on the appropriate screen, or unknown."}}`)),
+	}
+	errStr := getJiraErrorMessage(&netErr)
+	assert.EqualValues("summary: Field 'summary' cannot be set. It is not on the appropriate screen, or unknown.", errStr)
 }

--- a/internal/webhook.go
+++ b/internal/webhook.go
@@ -344,7 +344,7 @@ func (i *JiraIntegration) webhookCreateIssue(logger sdk.Logger, webhook sdk.WebH
 		ts := time.Now()
 		sdk.LogDebug(logger, "updating board for issue", "issue", issue.ID)
 		api := newAgileAPI(logger, state.authConfig, webhook.CustomerID(), webhook.IntegrationInstanceID(), i.httpmanager)
-		if err := updateIssueBoards(webhook.State(), pipe, api, webhook.CustomerID(), webhook.IntegrationInstanceID(), issue.Identifier, issue.ProjectID); err != nil {
+		if err := updateIssueBoards(webhook.State(), pipe, api, webhook.CustomerID(), webhook.IntegrationInstanceID(), issue.Identifier, *issue.ProjectID); err != nil {
 			return fmt.Errorf("error re-exporting board: %w", err)
 		}
 		sdk.LogDebug(logger, "done processing boards for issue", "issue", issue.ID, "duration", time.Since(ts))


### PR DESCRIPTION
_Because putting error messages in "errorMessages" would be too predictable_

With this change the returned error message should not be `HTTP: 400` anymore.