### PR TITLE
PROD-1170 Dont skip sprints that are now closed

### DIFF
--- a/internal/agile.go
+++ b/internal/agile.go
@@ -963,8 +963,8 @@ func exportBoard(api *agileAPI, state sdk.State, pipe sdk.Pipe, customerID strin
 				sprint.BoardIds = boardids
 			}
 			// only cache it if its closed, so open and future sprints always get exported
+			state.Delete(getSprintStateKeyLegacy(sid)) // clean up old key
 			if sprint.Status == sdk.AgileSprintStatusClosed {
-				state.Delete(getSprintStateKeyLegacy(sid)) // clean up old key
 				if err := state.Set(getSprintStateKey(sid), sdk.EpochNow()); err != nil {
 					return fmt.Errorf("error writing sprint key to state: %w", err)
 				}


### PR DESCRIPTION
The logic previously would skip exporting a sprint if it's closed, but this doesnt account for when the sprint went from open to closed => now the sprint is closed and wont be exported. we should be getting a webhook for this but in the case of a miss we should still export _some_ closed sprints