### PR TITLE
GOLD-477 Dont fail an export on an unsupported required field

### DIFF
--- a/internal/export.go
+++ b/internal/export.go
@@ -235,7 +235,7 @@ func (i *JiraIntegration) fetchProjectsPaginated(state *state) ([]string, error)
 					createMeta := meta[0]
 					return &createMeta, nil
 				}
-				capability, err := i.createProjectCapability(state.export.State(), p, project, getCreateMeta, state.historical)
+				capability, err := i.createProjectCapability(state.logger, state.export.State(), p, project, getCreateMeta, state.historical)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
If we can't figure out what the field is then just dont return any mutation fields, this will effectively disable the project for issue create mutations